### PR TITLE
Add explicit support for history in VRT files

### DIFF
--- a/processinghistory/history.py
+++ b/processinghistory/history.py
@@ -353,21 +353,21 @@ def readHistoryFromFile(filename=None, gdalDS=None):
 
     if procHistJSON is not None:
         procHist = ProcessingHistory.fromJSON(procHistJSON)
+
+        # If this is a VRT, then read the component files as though they were
+        # parent files
+        isVRT = (ds.GetDriver().ShortName == "VRT")
+        if isVRT:
+            vrtFile = ds.GetDescription()
+            componentList = [fn for fn in ds.GetFileList() if fn != vrtFile]
+            for componentFile in componentList:
+                if not os.path.exists(componentFile):
+                    msg = f"VRT file '{vrtFile}' missing component '{componentFile}'"
+                    raise ProcessingHistoryError(msg)
+
+                procHist.addParentHistory(componentFile)
     else:
         procHist = None
-
-    # If this is a VRT, then read the component files as though they were
-    # parent files
-    isVRT = (ds.GetDriver().ShortName == "VRT")
-    if isVRT:
-        vrtFile = ds.GetDescription()
-        componentList = [fn for fn in ds.GetFileList() if fn != vrtFile]
-        for componentFile in componentList:
-            if not os.path.exists(componentFile):
-                msg = f"VRT file '{vrtFile}' missing component '{componentFile}'"
-                raise ProcessingHistoryError(msg)
-
-            procHist.addParentHistory(componentFile)
 
     return procHist
 

--- a/processinghistory/history.py
+++ b/processinghistory/history.py
@@ -30,6 +30,15 @@ The parentsByKey dictionary has an entry for each file in the lineage, the
 value being a list of keys of the parents of that file. This dictionary stores
 all the ancestry relationships for the whole lineage.
 
+History in VRT files
+--------------------
+A GDAL VRT file is handled as a somewhat special case. The component files
+of the VRT are treated as parents of the VRT (and there can be no other parents),
+and the history of those files is read directly from them, rather than being
+copied into the VRT. This is handled transparently, so that when history
+is read from the VRT, it appears to have all come from there. This allows the
+history of the components to be as dynamic as the data itself.
+
 """
 import sys
 import os
@@ -362,7 +371,8 @@ def readHistoryFromFile(filename=None, gdalDS=None):
             componentList = [fn for fn in ds.GetFileList() if fn != vrtFile]
             for componentFile in componentList:
                 if not os.path.exists(componentFile):
-                    msg = f"VRT file '{vrtFile}' missing component '{componentFile}'"
+                    msg = (f"VRT file '{vrtFile}' missing component " +
+                           f"'{componentFile}'")
                     raise ProcessingHistoryError(msg)
 
                 procHist.addParentHistory(componentFile)


### PR DESCRIPTION
This addresses the discussion in #10 around VRT support

In the end, the solution was even simpler than the one discussed.

- It is an exception to give parents when adding history to a VRT file
- Only currentfile metadata is saved in the VRT. No lineage information is stored at all, deferred or otherwise.
- When reading history out of a VRT, all component files must be present (or the VRT would not work). So, the read function recursively reads the history from component files and adds it as though they were parents of the VRT. This creates the lineage on-the-fly. 
- The code for merging in parent history has moved to be a method in the class, so it can be shared between normal creation of a history object and on-the-fly creation for a VRT.

Note that this solution still does nothing to address the metadata size overflow problem mentioned. This mainly relates to GTiff format, but still needs care. It is possible we should do some separate fix for this, but that can come later.